### PR TITLE
Setup RSpec

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,21 @@ module ClothesCatalogApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+    
+    # RSpec will not generate test for
+    #   Helper/Views/JS/CSS
+    config.generators do |g|
+      g.test_framework :rspec, fixture: true
+      g.fixture_replacement :factory_bot, dir: 'spec/factories'
+      g.view_specs false
+      g.helper_specs false
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+    end
+    
+    # add another directory for rails to search when we require a file
+    config.autoload_paths += %W(\#{config.root}/lib)
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,9 @@ Rails.application.routes.draw do
                   contraints: {subdomain: 'api'},
                   paths: '/' do
     # /v1/
-    scope module: :v1 do
-      
+    scope module: :v1,
+          constraints: ApiConstraints.new(version: 1, default: true) do
+    
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,4 @@ Rails.application.routes.draw do
       
     end
   end
-  }
-  }
 end

--- a/lib/api_constraints.rb
+++ b/lib/api_constraints.rb
@@ -1,0 +1,11 @@
+# Validates the client request headers before deciding which version of the API to use
+class ApiConstraints
+  def initialize(options)
+    @version = options[:version]
+    @default = options[:default]
+  end
+
+  def matches?(request)
+    @default || request.headers['Accept'].include("application/vnd.marketplace.v#{@version}")
+  end
+end

--- a/lib/api_constraints.rb
+++ b/lib/api_constraints.rb
@@ -6,6 +6,6 @@ class ApiConstraints
   end
 
   def matches?(request)
-    @default || request.headers['Accept'].include("application/vnd.marketplace.v#{@version}")
+    @default || request.headers['Accept'].include?("application/vnd.marketplace.v#{@version}")
   end
 end

--- a/lib/spec/api_constraints_spec.rb
+++ b/lib/spec/api_constraints_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
+require_relative '../api_constraints'
 
 describe ApiConstraints do
   # Use let to define a memoized helper method
-  let(:api_contraints_v1) { ApiConstraints.new(version: 1) }
-  let(:api_contraints_v2) { ApiConstraints.new(version: 2, default: true) }
+  let(:api_constraints_v1) { ApiConstraints.new(version: 1) }
+  let(:api_constraints_v2) { ApiConstraints.new(version: 2, default: true) }
 
   describe 'matches?' do
-    context 'when the servers API Version matches the request "Accept" header version' do
-      # double is an object that we create to take the place of the real object in a test environment
-      request = double(host: 'api.market.dev',
-                       headers: {'Accept' => 'application/vnd.marketplace.v1'})
-      it { is_expected(api_constraints_v1.matches?(request)}.to be_true }
+    it "returns true when the version matches the 'Accept' header" do
+      request = double(host: 'api.marketplace.dev',
+                       headers: {"Accept" => "application/vnd.marketplace.v1"})
+      expect(api_constraints_v1.matches?(request)).to be true
     end
 
-    context 'when the default version is specified'
+    it "returns the default version when 'default' option is specified" do
       request = double(host: 'api.marketplace.dev')
-      it { is_expected(api_constraints_v2.matches?(request).version).to eq(2) }
+      expect(api_constraints_v2.matches?(request)).to be true
     end
   end
 end

--- a/lib/spec/api_constraints_spec.rb
+++ b/lib/spec/api_constraints_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe ApiConstraints do
+  # Use let to define a memoized helper method
+  let(:api_contraints_v1) { ApiConstraints.new(version: 1) }
+  let(:api_contraints_v2) { ApiConstraints.new(version: 2, default: true) }
+
+  describe 'matches?' do
+    context 'when the servers API Version matches the request "Accept" header version' do
+      # double is an object that we create to take the place of the real object in a test environment
+      request = double(host: 'api.market.dev',
+                       headers: {'Accept' => 'application/vnd.marketplace.v1'})
+      it { is_expected(api_constraints_v1.matches?(request)}.to be_true }
+    end
+
+    context 'when the default version is specified'
+      request = double(host: 'api.marketplace.dev')
+      it { is_expected(api_constraints_v2.matches?(request).version).to eq(2) }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,18 +7,6 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-# require database cleaner at the top level
-require 'database_cleaner'
-
-# configure shoulda matchers to use rspec as the test framework and full matcher libraries for rails
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
-  end
-end
-
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -36,32 +24,16 @@ end
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
-# ActiveRecord::Migration.maintain_test_schema!
+ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  # config.use_transactional_fixtures = true
-
-  # add `FactoryGirl` methods
-  config.include FactoryGirl::Syntax::Methods
-
-  # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  # start the transaction strategy as examples are run
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
-  end
+  config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -76,10 +48,10 @@ RSpec.configure do |config|
   #
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
-  # config.infer_spec_type_from_file_location!
+  config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.
-  # config.filter_rails_from_backtrace!
+  config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end


### PR DESCRIPTION
### Summary
Rspec is the test framework that we will use to support our Test Driven Development. The first example will be to validate the Api version using the clients request headers. The test file names takes the name of the file to test and adds 'spec' at the end of the file.

In TDD we first write the test case that we want to program. For example, we wanted to let the request header define the api version we use and so a test was written that uses the client request header to decide the api version and if one is not provided we use the default version provided by the server.

link: http://apionrails.icalialabs.com/book/chapter_two

### New Files & Folders
- lib/api_constraints.rb
- lib/spec/api_constraints_spec.rb

### Changes
- config/application.rb
  - Add on to the rails generators configuration settings
- config/routes.rb
  - Apply ApiConstraints to our route
- spec/rails_helper.rb
  - Reset the changes to what the tutorial says. The spec/rails_helper will change again soon to accommodate factory_bot and other test gems we may add in the future